### PR TITLE
Drop Elixir 1.9 support

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.9.4
-            otp: 20.3
           - elixir: 1.10.4
             otp: 21.3
           - elixir: 1.11.4

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Luhn.Mixfile do
   def project do
     [app: :luhn,
      version: "0.3.3",
-     elixir: "~> 1.9",
+     elixir: "~> 1.10",
      description: "Luhn algorithm in Elixir",
      package: [
        maintainers: ["Takayuki Matsubara"],


### PR DESCRIPTION
Minimum supported Elixir version is currently 1.10