### PR TITLE
Fix append check digit for base >= 12

### DIFF
--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -71,8 +71,8 @@ defmodule Luhn do
       iex> Luhn.compute_check_digit(7992739871)
       3
   """
-  @spec compute_check_digit(input) :: check_digit
-  def compute_check_digit(n), do: Algorithm.compute_check_digit(n)
+  @spec compute_check_digit(input, pos_integer) :: check_digit
+  def compute_check_digit(n, base \\ 10) when valid_base(base), do: Algorithm.compute_check_digit(n, base)
 
   @doc """
   Compute and append the check digit for a given number.
@@ -80,10 +80,10 @@ defmodule Luhn do
       iex> Luhn.append_check_digit("7992739871")
       "79927398713"
   """
-  @spec append_check_digit(binary) :: binary
-  def append_check_digit(n) do
-    check_digit = Algorithm.compute_check_digit(n)
-    n <> to_string(check_digit)
+  @spec append_check_digit(binary, pos_integer) :: binary
+  def append_check_digit(n, base \\ 10) do
+    check_digit = Algorithm.compute_check_digit(n, base)
+    n <> Integer.to_string(check_digit, base)
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Luhn.Mixfile do
   def project do
     [
       app: :luhn60,
-      version: "1.3.8",
+      version: "1.3.12",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Luhn algorithm in Elixir",

--- a/test/helpers/luhn_generators.ex
+++ b/test/helpers/luhn_generators.ex
@@ -1,6 +1,9 @@
 defmodule Luhn.Generators do
   use PropCheck
 
+  @min_base 2
+  @max_base 36
+
   @doc "Good number from the Wikipedia article"
   def wikipedia_number, do: exactly("79927398713")
 
@@ -13,26 +16,41 @@ defmodule Luhn.Generators do
     elements(digits)
   end
 
-  @doc "Base 10 digit"
+  def digits(base) when base <= @max_base do
+    digits = for i <- 0..9, do: ?0 + i
+    letters = for i <- 10..(base-1), do: ?A + i - 10
+    elements(digits ++ letters)
+  end
+
+  @doc "Decimal digit (base 10)"
   def decimal_digit, do: digits(10)
 
-  @doc "Octal digit"
+  @doc "Octal digit (base 8)"
   def octal_digit, do: digits(8)
 
-  @doc "Numeric string (base 10)"
-  def numeric_10 do
-    let n <- choose(8, 19) do
-      let digits <- vector(n, decimal_digit()) do
-        to_string(digits)
-      end
-    end
-  end
+  @doc "Non-zero digit"
+  def nz_digit(gen), do: such_that(d <- gen, when: d != ?0)
 
   @doc "Numeric string of given chars"
   def numeric(digit_gen) do
     let n <- choose(2, 19) do
-      let digits <- vector(n, digit_gen) do
-        to_string(digits)
+      let {d, ds} <- {nz_digit(digit_gen), vector(n-1, digit_gen)} do
+        to_string([d|ds])
+      end
+    end
+  end
+
+  @doc "Numeric string (base 10)"
+  def numeric_10, do: numeric(decimal_digit())
+
+  @doc "Supported base"
+  def base, do: choose(@min_base, @max_base)
+
+  @doc "Base and numeric in that base"
+  def numeric_in_base do
+    let base <- base() do
+      let n <- numeric(digits(base)) do
+        {n, base}
       end
     end
   end

--- a/test/luhn_check_test.exs
+++ b/test/luhn_check_test.exs
@@ -81,9 +81,17 @@ defmodule Luhn.CheckTest do
     end
 
     property "appends valid check digit octal" do
+      base = 8
       forall n <- numeric(octal_digit()) do
-        n_checked = Luhn.append_check_digit(n)
-        assert Luhn.valid?(n_checked)
+        n_checked = Luhn.append_check_digit(n, base)
+        assert Luhn.valid?(n_checked, base)
+      end
+    end
+
+    property "increases length by one digit" do
+      forall {n, base} <- numeric_in_base() do
+        n_checked = Luhn.append_check_digit(n, base)
+        assert String.length(n_checked) == (String.length(n) + 1)
       end
     end
   end


### PR DESCRIPTION
The check digit for 502 in base 12 is 10, which needs to be appended as A and not 10